### PR TITLE
Added the ability to run readAudios in a separate thread

### DIFF
--- a/android/src/main/kotlin/com/lucasjosino/on_audio_edit/methods/read/OnAudioRead.kt
+++ b/android/src/main/kotlin/com/lucasjosino/on_audio_edit/methods/read/OnAudioRead.kt
@@ -42,6 +42,17 @@ class OnAudioRead {
 
     //
     fun readAudios(result: MethodChannel.Result, call: MethodCall) {
+        val separateThread: Boolean = call.argument("separateThread")!!
+        if (separateThread) {
+            Thread {
+                onReadAudios(result, call)
+            }.start()
+        } else {
+            onReadAudios(result, call)
+        }
+    }
+
+    private fun onReadAudios(result: MethodChannel.Result, call: MethodCall) {
         // Get all information from Dart.
         val data: ArrayList<String> = call.argument("data")!!
 

--- a/lib/details/on_audio_edit_controller.dart
+++ b/lib/details/on_audio_edit_controller.dart
@@ -68,6 +68,7 @@ class OnAudioEdit {
   /// Parameters:
   ///
   /// * [data] is used for find multiples audios data.
+  /// * [mainThread] if `true` execute code in separate thread.
   ///
   /// Usage:
   ///
@@ -83,10 +84,14 @@ class OnAudioEdit {
   /// * Calling any method without [READ] and [WRITE] permission will throw a error.
   ///
   /// Use [permissionsStatus] to see permissions status.
-  Future<List<AudioModel>> readAudios(List<String> data) async {
+  Future<List<AudioModel>> readAudios(
+    List<String> data, {
+    bool separateThread = false,
+  }) async {
     final List<dynamic> resultReadAudio =
         await _channel.invokeMethod("readAudios", {
       "data": data,
+      "separateThread": separateThread,
     });
     return resultReadAudio.map((e) => AudioModel(e)).toList();
   }


### PR DESCRIPTION
When using OnAudioEdit.readAudios it blocks the main thread as a result of the ui.

A flag has been added to allow this method to run on a secondary thread so as not to block the ui